### PR TITLE
Replaced the ‘Fork me on Github’ ribbon with a high-DPI (retina) version...

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,8 +62,9 @@
 
   <div id="top">
     <a target="_blank" href="https://github.com/syncthing/syncthing">
-      <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67"
-      alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png">
+
+    <img style="position: absolute; top: 0; right: 0; border: 0; width: 149px; height: 149px;" src="http://aral.github.com/fork-me-on-github-retina-ribbons/right-grey@2x.png" alt="Fork me on GitHub">
+
     </a>
     <div class="container-fluid container">
       <div class="jumbotron">


### PR DESCRIPTION
The web site deserves a crisp ‘fork me’ icon :) Used one of mine from https://aralbalkan.com/scribbles/fork-me-on-github-retina-ribbons/
