### PR TITLE
Pedantic UPnP capitalization edit

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,7 +181,7 @@
               <ul>
                 <li><strong>Web GUI.</strong> Configure and monitor Syncthing via a responsive and powerful interface accessible via your browser.</li>
                 <li><strong>Portable.</strong> Works on Mac OS X, Windows, Linux, FreeBSD and Solaris. Run it on your desktop computers and synchronize them with your server for backup.</li>
-                <li><strong>Simple.</strong> Syncthing doesn't need IP addresses or advanced configuration: it just works, over LAN and over the Internet. Every machine is identified by an ID. Just give your ID to you friends, share a folder and watch: uPnP
+                <li><strong>Simple.</strong> Syncthing doesn't need IP addresses or advanced configuration: it just works, over LAN and over the Internet. Every machine is identified by an ID. Just give your ID to you friends, share a folder and watch: UPnP
                   will do if you don't want to port forward or you don't know how.</li>
                 <li><strong>Powerful.</strong> Synchronize as many folders as you need with different people.
               </ul>


### PR DESCRIPTION
The 'u' in UPnP is capitalized: see http://www.upnp.org/
