### PR TITLE
Add direct download links

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -116,3 +116,24 @@ Breakpoint: viewport too narrow for two-column, go to one column (as per bootstr
 		margin-top: 20px;
 	}
 }
+
+#dynamic-downloads {
+	display: none;
+}
+
+#download-header {
+	text-align: center;
+}
+
+#download-links {
+	-moz-columns: 2;
+	-webkit-columns: 2;
+	columns: 2;
+	text-align: center;
+}
+
+#download-links ul, #download-links ul li {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}

--- a/index.html
+++ b/index.html
@@ -72,11 +72,17 @@
                     <hr/>
                     <div class="row">
                         <div class="col-md-6">
-                            <h3 class="text-center">Windows, Linux, Mac, BSD and Solaris</h3>
-                            <p class="text-center">
-                                <a class="btn btn-primary btn-lg" href="https://github.com/syncthing/syncthing/releases/latest">
-                                    <i class="fa fa-github"></i>&nbsp;Download from GitHub</a>
-                            </p>
+                            <h3 class="text-center">Syncthing Core (CLI &amp; Web UI)</h3>
+                            <div id="static-download">
+                                <p class="text-center" id="download-button">
+                                    <a class="btn btn-primary btn-lg" href="https://github.com/syncthing/syncthing/releases/latest">
+                                        <i class="fa fa-github"></i>&nbsp;Download from GitHub</a>
+                                </p>
+                            </div>
+                            <div id="dynamic-downloads">
+                                <h4 id="download-header"></h4>
+                                <p id="download-links"></p>
+                            </div>
                             <p class="text-center"> Make sure to check out the
                                 <a href="https://github.com/syncthing/syncthing/wiki/Getting-Started">Getting Started Guide</a> if you need help. Releases are signed as described on the
                                 <a href="security.html">security</a> page.</p>
@@ -251,6 +257,7 @@
         </div>
     </div>
     <script type="text/javascript" src="bower_components/jquery/dist/jquery.min.js"></script>
+    <script type="text/javascript" src="js/downloads.js"></script>
     <script type="text/javascript" src="https://blockchain.info/Resources/wallet/pay-now-button.js" async></script>
 </body>
 

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -1,0 +1,77 @@
+$.getJSON('https://api.github.com/repos/syncthing/syncthing/releases/latest', function(data) {
+    $('<span>Latest is ' + data.tag_name + '</span>').appendTo('#download-header')
+
+    var links = {};
+    $.each(data.assets, function(i, asset) {
+        var m = asset.name.match(/syncthing-(\w+)-(\w+)/);
+        if (!m) {
+            return
+        }
+
+        var os = m[1];
+        var arch = m[2];
+        var order = 'Y'; // used for sorting
+
+        if (os === 'linux') {
+            os = 'Linux';
+            order = 'A';
+        } else if (os === 'windows') {
+            os = 'Windows';
+            order = 'B';
+        } else if (os === 'macosx') {
+            os = 'Mac OS X';
+            order = 'C';
+        } else if (os === 'freebsd') {
+            os = 'FreeBSD';
+            order = 'D';
+        } else if (os === 'solaris') {
+            os = 'Solaris';
+            order = 'E';
+        } else if (os === 'netbsd') {
+            os = 'NetBSD';
+            order = 'F'
+        } else if (os === 'openbsd') {
+            os = 'OpenBSD';
+            order = 'F'
+        } else if (os === 'dragonfly') {
+            os = 'Dragonfly BSD';
+            order = 'F'
+        } else if (os === 'source') {
+            os = 'Source Code';
+            arch = data.tag_name;
+            order = 'Z';
+        }
+
+        if (arch === 'amd64') {
+            arch = '64 bit';
+        } else if (arch === '386') {
+            arch = '32 bit';
+        } else if (arch === 'arm') {
+            arch = 'ARM';
+        }
+
+        var l = links[order + os];
+        if (!l) {
+            l = [];
+        }
+        l.push('<a href="' + asset.browser_download_url + '">' + arch + '</a>');
+        links[order + os] = l;
+    });
+
+    var keys = Object.keys(links);
+    keys.sort();
+
+    var items = [];
+    for (var i = 0; i < keys.length; i++) {
+        var os = keys[i].substr(1);
+        items.push('<li>' + os + ': ' + links[keys[i]].join(', ')) + '</li>';
+    }
+
+    $("<ul/>", {
+        "class": "my-new-list",
+        html: items.join("")
+    }).appendTo('#download-links');
+
+    $('#dynamic-downloads').css('display', 'block');
+    $('#static-download').hide();
+});


### PR DESCRIPTION
This adds direct download links by Javascript, and also updates the section header to make more sense in the context. When the page loads, it displays the regular static download info:

![screen shot 2015-05-10 at 22 43 29](https://cloud.githubusercontent.com/assets/125426/7556164/085d6104-f766-11e4-9be1-bc28ad0b65b2.png)

If an API call to Github succeeds, the section is replaced with the following:

![screen shot 2015-05-10 at 22 43 36](https://cloud.githubusercontent.com/assets/125426/7556165/11c767d0-f766-11e4-8452-84bab8970c7b.png)

A future exercise is nicer styling and OS autodetection...
