### PR TITLE
Correct example of verifying sha1sum.txt.asc

### DIFF
--- a/security.html
+++ b/security.html
@@ -136,10 +136,10 @@ gpg:               imported: 2  (RSA: 2)
 
 $ <b>gpg --verify sha1sum.txt.asc</b>
 gpg: Signature made Mon 29 Dec 2014 09:51:39 AM CET using RSA key ID BCE524C7
-<b>gpg: Good signature from "Jakob Borg (calmh) &lt;jakob@nym.se&gt;"</b>
+<b>gpg: Good signature from "Syncthing Release Management &lt;release@syncthing.net&gt;"</b>
 gpg: WARNING: This key is not certified with a trusted signature!
 gpg:          There is no indication that the signature belongs to the owner.
-Primary key fingerprint: 9DCC 29A8 312F 5C0F 2625  E76E 49F5 AEC0 BCE5 24C7
+Primary key fingerprint: 37C8 4554 E7E0 A261 E4F7  6E1E D26E 6ED0 0065 4A3E
 </pre>
 
 <h2>Contacting the Syncthing Team Securely</h2>


### PR DESCRIPTION
The example was for a sha1sum.txt.asc signed by jakob@nym.se (49F5AEC0BCE524C7).
However newer sha1sum.txt.asc files are signed by release@syncthing.net (D26E6ED000654A3E).
Update the example of verifying the signature on sha1sum.txt.asc to reflect this.
