### PR TITLE
Change Play Store Logo URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
                             </p>
                             <p>
                                 <a href="https://play.google.com/store/apps/details?id=com.nutomic.syncthingandroid">
-                                    <img alt="Get it on Google Play" src="https://developer.android.com/images/brand/en_generic_rgb_wo_60.png">
+                                    <img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/apps/en-play-badge.png">
                                 </a>
                                 <a href="https://f-droid.org/repository/browse/?fdid=com.nutomic.syncthingandroid">
                                     <img alt="Get it on F-Droid" src="https://f-droid.org/wiki/images/0/06/F-Droid-button_get-it-on.png">


### PR DESCRIPTION
Change the Google Play Sore Logo URL, as the current one does not work anymore.

The URL was generated on https://play.google.com/intl/en_us/badges/.
