### PR TITLE
Set correct height for new Google Play Store Logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
                             </p>
                             <p>
                                 <a href="https://play.google.com/store/apps/details?id=com.nutomic.syncthingandroid">
-                                    <img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/apps/en-play-badge.png">
+                                    <img style="height:60px;" alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/apps/en-play-badge.png">
                                 </a>
                                 <a href="https://f-droid.org/repository/browse/?fdid=com.nutomic.syncthingandroid">
                                     <img alt="Get it on F-Droid" src="https://f-droid.org/wiki/images/0/06/F-Droid-button_get-it-on.png">


### PR DESCRIPTION
Sorry. I did not realize that the new Logo was way bigger than the old. The preview on the google site had the more or less correct size.
I now set the height to 60, which is the same as the Logo for F-Droid.
