### PR TITLE
Add IDs to allow linking specific content

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
                 </div>
             </div>
             <div class="row">
-                <div  id="easy-to-use" class="col-sm-12">
+                <div id="easy-to-use" class="col-sm-12">
                     <h2>
                         <i class="title fa fa-users"></i>Easy to Use</h2>
                     <hr/>

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
     <div id="main">
         <div class="container">
             <div class="row">
-                <div class="col-md-12">
+                <div id="get-started" class="col-md-12">
                     <h2>
                         <i class="title fa fa-download"></i>Get Started</h2>
                     <hr/>
@@ -112,7 +112,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-sm-12">
+                <div id="secure-private" class="col-sm-12">
                     <h2>
                         <i class="title fa fa-lock"></i>Secure &amp; Private</h2>
                     <hr/>
@@ -134,7 +134,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-sm-12">
+                <div id="open-development" class="col-sm-12">
                     <h2>
                         <i class="title fa fa-code-fork"></i>Open Development</h2>
                     <hr/>
@@ -171,7 +171,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-sm-12">
+                <div  id="easy-to-use" class="col-sm-12">
                     <h2>
                         <i class="title fa fa-users"></i>Easy to Use</h2>
                     <hr/>
@@ -197,7 +197,7 @@
             </div>
 
             <div class="row">
-                <div class="col-md-12">
+                <div id="donate" class="col-md-12">
                     <h2><i class="title fa fa-heart"></i>Donate</h2>
                     <hr/>
 


### PR DESCRIPTION
Because our website doesn't have subpages there is currently no way to link to e.g. the download links or the donation page. With IDs, it's very easy to link to such content via https://syncthing.net#id

This can be useful for internal usage (links in the UI, documentation, forums) as well as external usage by bloggers and power users trying to give their loved ones no possible way to miss the download section.
