### PR TITLE
Give more screen time to GUI wrappers

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,20 +93,21 @@
                         <div class="col-md-6">
                             <h3>Third-party contributions</h3>
                             <p>
-                                <a href="https://github.com/syncthing/syncthing-android">Android app</a>
+                                <ul>
+                                    <li>Windows tray utility, filesystem watcher & launcher: <a href="https://github.com/canton7/SyncTrayzor/releases/latest">SyncTrayzor</a>
+                                    <li>Cross-platform GUI wrapper: <a href="https://github.com/syncthing/syncthing-gtk/releases/latest">Syncthing-GTK</a>
+                                    <li>
+                                        Android app:<br>
+                                        <a href="https://play.google.com/store/apps/details?id=com.nutomic.syncthingandroid"><img style="height:40px;" alt="Get it on Google Play" src="images/google-play-badge.png"></a>
+                                        <a href="https://f-droid.org/repository/browse/?fdid=com.nutomic.syncthingandroid"><img style="height:40px;" alt="Get it on F-Droid" src="images/fdroid-badge.png"></a>
+                                        <br><small>See also <a href="https://github.com/syncthing/syncthing-android">Source and Issue Tracker</a> for the Android app</small>
+                                    <li>Filesystem watcher: <a href="https://github.com/syncthing/syncthing-inotify/releases/latest">Syncthing-inotify</a><br><small>(bundled in SyncTrayzor, Syncthing-GTK and the Android app)</small>
+                                    <li>Many, many other <a href="https://docs.syncthing.net/users/contrib.html">community contributions</a>.
+                                </ul>
                             </p>
                             <p>
-                                <a href="https://play.google.com/store/apps/details?id=com.nutomic.syncthingandroid">
-                                    <img style="height:80px;" alt="Get it on Google Play" src="images/google-play-badge.png">
-                                </a>
-                                <a href="https://f-droid.org/repository/browse/?fdid=com.nutomic.syncthingandroid">
-                                    <img style="height:80px;" alt="Get it on F-Droid" src="images/fdroid-badge.png">
-                                </a>
                             </p>
                             <p>
-                                <a href="https://github.com/syncthing/syncthing-gtk">Cross-platform GUI wrapper</a>,
-                                <a href="https://github.com/syncthing/syncthing-inotify/releases/latest">filesystem watcher</a>, and
-                                <a href="https://docs.syncthing.net/users/contrib.html">other</a> community contributions.</p>
                         </div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
                     <hr/>
                     <div class="row">
                         <div class="col-md-6">
-                            <h3>Native Integrations</h3>
+                            <h3>Native GUIs & Integrations</h3>
                             <p>
                                 <ul>
                                     <li><b>Windows</b> tray utility, filesystem watcher & launcher: <a href="https://github.com/canton7/SyncTrayzor/releases/latest">SyncTrayzor</a>

--- a/index.html
+++ b/index.html
@@ -75,6 +75,27 @@
                     <hr/>
                     <div class="row">
                         <div class="col-md-6">
+                            <h3>Native Integrations</h3>
+                            <p>
+                                <ul>
+                                    <li><b>Windows</b> tray utility, filesystem watcher & launcher: <a href="https://github.com/canton7/SyncTrayzor/releases/latest">SyncTrayzor</a>
+                                    <li><b>Cross-platform</b> GUI wrapper: <a href="https://github.com/syncthing/syncthing-gtk/releases/latest">Syncthing-GTK</a>
+                                    <li>
+                                        <b>Android</b> app:<br>
+                                        <a href="https://play.google.com/store/apps/details?id=com.nutomic.syncthingandroid"><img style="height:40px;" alt="Get it on Google Play" src="images/google-play-badge.png"></a>
+                                        <a href="https://f-droid.org/repository/browse/?fdid=com.nutomic.syncthingandroid"><img style="height:40px;" alt="Get it on F-Droid" src="images/fdroid-badge.png"></a>
+                                        <br><small>See also <a href="https://github.com/syncthing/syncthing-android">Source and Issue Tracker</a> for the Android app</small>
+                                </ul>
+                            </p>
+                            <h3>Other Components and Contributions</h3>
+                            <p>
+                                <ul>
+                                    <li>Filesystem watcher: <a href="https://github.com/syncthing/syncthing-inotify/releases/latest">Syncthing-inotify</a><br><small>(bundled in SyncTrayzor, Syncthing-GTK and the Android app)</small>
+                                    <li>Many, many other <a href="https://docs.syncthing.net/users/contrib.html">community contributions</a>.
+                                </ul>
+                            </p>
+                        </div>
+                        <div class="col-md-6">
                             <h3>Syncthing Core (CLI &amp; Web UI)</h3>
                             <div id="static-download">
                                 <p id="download-button">
@@ -89,25 +110,6 @@
                             <p>There are also <a href="https://apt.syncthing.net/">Debian / Ubuntu packages</a> available. Make sure to check out the
                                 <a href="https://docs.syncthing.net/intro/getting-started.html">Getting Started Guide</a> if you need help. Releases are signed as described on the
                                 <a href="security.html">security</a> page.</p>
-                        </div>
-                        <div class="col-md-6">
-                            <h3>Third-party contributions</h3>
-                            <p>
-                                <ul>
-                                    <li>Windows tray utility, filesystem watcher & launcher: <a href="https://github.com/canton7/SyncTrayzor/releases/latest">SyncTrayzor</a>
-                                    <li>Cross-platform GUI wrapper: <a href="https://github.com/syncthing/syncthing-gtk/releases/latest">Syncthing-GTK</a>
-                                    <li>
-                                        Android app:<br>
-                                        <a href="https://play.google.com/store/apps/details?id=com.nutomic.syncthingandroid"><img style="height:40px;" alt="Get it on Google Play" src="images/google-play-badge.png"></a>
-                                        <a href="https://f-droid.org/repository/browse/?fdid=com.nutomic.syncthingandroid"><img style="height:40px;" alt="Get it on F-Droid" src="images/fdroid-badge.png"></a>
-                                        <br><small>See also <a href="https://github.com/syncthing/syncthing-android">Source and Issue Tracker</a> for the Android app</small>
-                                    <li>Filesystem watcher: <a href="https://github.com/syncthing/syncthing-inotify/releases/latest">Syncthing-inotify</a><br><small>(bundled in SyncTrayzor, Syncthing-GTK and the Android app)</small>
-                                    <li>Many, many other <a href="https://docs.syncthing.net/users/contrib.html">community contributions</a>.
-                                </ul>
-                            </p>
-                            <p>
-                            </p>
-                            <p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Adds SyncTrayzor, rearranges a little.

Normal browser:

<img width="850" alt="screen shot 2017-01-02 at 13 26 32" src="https://cloud.githubusercontent.com/assets/125426/21589155/403372d0-d0ef-11e6-9c80-3042f0add1db.png">

Phone:

<img width="367" alt="screen shot 2017-01-02 at 13 26 08" src="https://cloud.githubusercontent.com/assets/125426/21589158/45fc2eaa-d0ef-11e6-9da9-eae202a78656.png">
