### PR TITLE
remove Syncthing-inotify

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,8 +90,7 @@
                             <h3>Other Components and Contributions</h3>
                             <p>
                                 <ul>
-                                    <li>Filesystem watcher: <a href="https://github.com/syncthing/syncthing-inotify/releases/latest">Syncthing-inotify</a><br><small>(bundled in SyncTrayzor, Syncthing-GTK and the Android app)</small>
-                                    <li>Many, many other <a href="https://docs.syncthing.net/users/contrib.html">community contributions</a>.
+                                    <li>Many, many <a href="https://docs.syncthing.net/users/contrib.html">community contributions</a>.
                                 </ul>
                             </p>
                         </div>


### PR DESCRIPTION
Since it's deprecated since syncthing v0.14.40: https://github.com/syncthing/syncthing-inotify/commit/c973c5677bd05ee259cd79ce277888eb89c9d746#diff-04c6e90faac2675aa89e2176d2eec7d8