### PR TITLE
Add macOS xor-gate/synthing-macosx to native integrations section

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,7 @@
                             <p>
                                 <ul>
                                     <li><b>Windows</b> tray utility, filesystem watcher & launcher: <a href="https://github.com/canton7/SyncTrayzor/releases/latest">SyncTrayzor</a>
+                                    <li><b>macOS</b> application bundle: <a href="https://github.com/xor-gate/syncthing-macosx/releases/latest">syncthing-macosx</a>
                                     <li><b>Cross-platform</b> GUI wrapper: <a href="https://github.com/syncthing/syncthing-gtk/releases/latest">Syncthing-GTK</a>
                                     <li>
                                         <b>Android</b> app:<br>


### PR DESCRIPTION
As discussed on the forum https://forum.syncthing.net/t/this-is-why-we-need-a-mac-app-installer/11709/9?u=jerryjacobs